### PR TITLE
Add: database statement classes

### DIFF
--- a/src/system/Papaya/Administration/Community/Users/Roster/Dialog.php
+++ b/src/system/Papaya/Administration/Community/Users/Roster/Dialog.php
@@ -155,29 +155,23 @@ class Dialog extends \Papaya\UI\Dialog {
       $this->_listview->builder(
         $builder = new \Papaya\UI\ListView\Items\Builder($this->users())
       );
-      $builder->callbacks()->onCreateItem = array($this, 'createUserItem');
+      $builder->callbacks()->onCreateItem = function(
+        /** @noinspection PhpUnusedParameterInspection */
+        $context, \Papaya\UI\ListView\Items $items, array $user
+      ) {
+        $items[] = new \Papaya\UI\ListView\Item(
+          'items-user',
+          empty($user['caption']) ? $user['email'] : $user['caption'],
+          array(
+            $this->_parameterNames['user'] => $user['id'],
+            $this->_parameterNames['filter'] => $this->data()->get('filter'),
+            $this->_parameterNames['page'] => $this->paging()->currentPage
+          ),
+          $this->parameters()->get($this->_parameterNames['user']) === $user['id']
+        );
+      };
     }
     return $this->_listview;
-  }
-
-  /**
-   * Create a listview item for a community user record.
-   *
-   * @param object $context
-   * @param \Papaya\UI\ListView\Items $items
-   * @param array $user
-   */
-  public function createUserItem($context, $items, $user) {
-    $items[] = new \Papaya\UI\ListView\Item(
-      'items-user',
-      empty($user['caption']) ? $user['email'] : $user['caption'],
-      array(
-        $this->_parameterNames['user'] => $user['id'],
-        $this->_parameterNames['filter'] => $this->data()->get('filter'),
-        $this->_parameterNames['page'] => $this->paging()->currentPage
-      ),
-      $this->parameters()->get($this->_parameterNames['user']) === $user['id']
-    );
   }
 
   /**

--- a/src/system/Papaya/Administration/Page.php
+++ b/src/system/Papaya/Administration/Page.php
@@ -107,9 +107,7 @@ abstract class Page extends \Papaya\Application\BaseObject {
   public function execute() {
     if (!$this->validateAccess()) {
       $this->papaya()->messages->display(
-        \Papaya\Message::SEVERITY_ERROR, new \Papaya\UI\Text\Translated(
-           'Access forbidden.'
-         )
+        \Papaya\Message::SEVERITY_ERROR, 'Access forbidden.'
       );
       return;
     }

--- a/src/system/Papaya/Administration/Pages/Dependency/Command/Change.php
+++ b/src/system/Papaya/Administration/Pages/Dependency/Command/Change.php
@@ -178,10 +178,8 @@ class Change extends \Papaya\UI\Control\Command\Dialog {
    */
   public function handleExecutionSuccess($context) {
     $context->synchronizations->synchronizeDependency($context->dependency);
-    $this->papaya()->messages->dispatch(
-      new \Papaya\Message\Display\Translated(
-        \Papaya\Message::SEVERITY_INFO, 'Dependency saved.'
-      )
+    $this->papaya()->messages->display(
+      \Papaya\Message::SEVERITY_INFO, 'Dependency saved.'
     );
   }
 
@@ -189,12 +187,10 @@ class Change extends \Papaya\UI\Control\Command\Dialog {
    * Callback to dispatch a message to the user that here was an input error.
    */
   public function dispatchErrorMessage($context, \Papaya\UI\Dialog $dialog) {
-    $this->papaya()->messages->dispatch(
-      new \Papaya\Message\Display\Translated(
-        \Papaya\Message::SEVERITY_ERROR,
-        'Invalid input. Please check the fields "%s".',
-        array(implode(', ', $dialog->errors()->getSourceCaptions()))
-      )
+    $this->papaya()->messages->display(
+      \Papaya\Message::SEVERITY_ERROR,
+      'Invalid input. Please check the following fields: "%s".',
+      [implode(', ', $dialog->errors()->getSourceCaptions())]
     );
   }
 }

--- a/src/system/Papaya/Autoloader.php
+++ b/src/system/Papaya/Autoloader.php
@@ -130,6 +130,7 @@ class Autoloader {
     'PapayaUiListviewSubitemImageSelect' => UI\ListView\SubItem\Image\Toggle::class,
     'PapayaUiToolbarSet' => UI\Toolbar\Collection::class
   );
+  private static $_mapClassesReverse;
 
   private static $_mapParts = array(
     // Reserved Words
@@ -169,6 +170,7 @@ class Autoloader {
     'Xml' => 'XML',
     'Xslt' => 'XSLT'
   );
+  private static $_mapPartsReverse;
 
   /**
    *
@@ -200,6 +202,8 @@ class Autoloader {
           } else {
             class_alias($name, $alias);
           }
+        } elseif (FALSE !== strpos($name, '\\') && ($alias = self::convertToToOldClass($name))) {
+          class_alias($name, $alias);
         }
       }
     }
@@ -268,6 +272,33 @@ class Autoloader {
       return substr($result, 1);
     }
     return $className;
+  }
+
+  /**
+   *  Convert a new (namespaced class back to its old class name)
+   *
+   * @param string $className
+   * @return NULL|string
+   */
+  private static function convertToToOldClass($className) {
+    if (NULL === self::$_mapClassesReverse) {
+      self::$_mapClassesReverse = array_flip(self::$_mapClasses);
+    }
+    if (isset(self::$_mapClassesReverse[$className])) {
+      return self::$_mapClassesReverse[$className];
+    }
+    if (NULL === self::$_mapPartsReverse) {
+      self::$_mapPartsReverse = array_flip(self::$_mapParts);
+    }
+    $parts = explode('\\', $className);
+    $result = '';
+    foreach ($parts as $part) {
+      if (isset(self::$_mapPartsReverse[$part])) {
+        $part = self::$_mapPartsReverse[$part];
+      }
+      $result .= $part;
+    }
+    return $result ?: NULL;
   }
 
   /**

--- a/src/system/Papaya/Content/View/Configurations.php
+++ b/src/system/Papaya/Content/View/Configurations.php
@@ -22,6 +22,10 @@ namespace Papaya\Content\View;
  */
 class Configurations extends \Papaya\Database\Records\Lazy {
 
+  public const TYPE_OUTPUT = \Papaya\Plugin\Types::OUTPUT;
+  public const TYPE_FILTER = \Papaya\Plugin\Types::FILTER;
+  public const TYPE_IMPORT = \Papaya\Plugin\Types::IMPORT;
+
   /**
    * Map field names to more convenient property names
    *
@@ -35,14 +39,14 @@ class Configurations extends \Papaya\Database\Records\Lazy {
     'options' => 'viewlink_data'
   );
 
+  protected $_identifierProperties = ['id', 'mode_id', 'type'];
+
   /**
    * Table containing view informations
    *
    * @var string
    */
   protected $_tableName = \Papaya\Content\Tables::VIEW_CONFIGURATIONS;
-
-  protected $_identifierProperties = ['id', 'mode_id', 'type'];
 
   /**
    * @param array|string|int $filter
@@ -57,7 +61,7 @@ class Configurations extends \Papaya\Database\Records\Lazy {
       $conditionOutput = sprintf(' WHERE vl.viewmode_id = %d', $filter['mode_id']);
       $conditionData = sprintf(' WHERE vl.datafilter_id = %d', $filter['mode_id']);
       unset($filter['mode_id']);
-      $prefix = '';
+      $prefix = ' AND ';
     } else {
       $conditionOutput = $conditionData = '';
     }

--- a/src/system/Papaya/Content/View/Configurations.php
+++ b/src/system/Papaya/Content/View/Configurations.php
@@ -22,9 +22,9 @@ namespace Papaya\Content\View;
  */
 class Configurations extends \Papaya\Database\Records\Lazy {
 
-  public const TYPE_OUTPUT = \Papaya\Plugin\Types::OUTPUT;
-  public const TYPE_FILTER = \Papaya\Plugin\Types::FILTER;
-  public const TYPE_IMPORT = \Papaya\Plugin\Types::IMPORT;
+  const TYPE_OUTPUT = \Papaya\Plugin\Types::OUTPUT;
+  const TYPE_FILTER = \Papaya\Plugin\Types::FILTER;
+  const TYPE_IMPORT = \Papaya\Plugin\Types::IMPORT;
 
   /**
    * Map field names to more convenient property names
@@ -56,10 +56,10 @@ class Configurations extends \Papaya\Database\Records\Lazy {
    */
   public function load($filter = array(), $limit = NULL, $offset = NULL) {
     $databaseAccess = $this->getDatabaseAccess();
-    $prefix = " WHERE ";
-    if (array_key_exists('mode_id', $filter)) {
-      $conditionOutput = sprintf(' WHERE vl.viewmode_id = %d', $filter['mode_id']);
-      $conditionData = sprintf(' WHERE vl.datafilter_id = %d', $filter['mode_id']);
+    $prefix = ' WHERE ';
+    if (\is_array($filter) && \array_key_exists('mode_id', $filter)) {
+      $conditionOutput = \sprintf(' WHERE vl.viewmode_id = %d', (int)$filter['mode_id']);
+      $conditionData = \sprintf(' WHERE vl.datafilter_id = %d', (int)$filter['mode_id']);
       unset($filter['mode_id']);
       $prefix = ' AND ';
     } else {

--- a/src/system/Papaya/Content/View/Configurations.php
+++ b/src/system/Papaya/Content/View/Configurations.php
@@ -57,7 +57,7 @@ class Configurations extends \Papaya\Database\Records\Lazy {
   public function load($filter = array(), $limit = NULL, $offset = NULL) {
     $databaseAccess = $this->getDatabaseAccess();
     $prefix = " WHERE ";
-    if (isset($filter['mode_id'])) {
+    if (array_key_exists('mode_id', $filter)) {
       $conditionOutput = sprintf(' WHERE vl.viewmode_id = %d', $filter['mode_id']);
       $conditionData = sprintf(' WHERE vl.datafilter_id = %d', $filter['mode_id']);
       unset($filter['mode_id']);

--- a/src/system/Papaya/Content/View/Configurations.php
+++ b/src/system/Papaya/Content/View/Configurations.php
@@ -42,6 +42,8 @@ class Configurations extends \Papaya\Database\Records\Lazy {
    */
   protected $_tableName = \Papaya\Content\Tables::VIEW_CONFIGURATIONS;
 
+  protected $_identifierProperties = ['id', 'mode_id', 'type'];
+
   /**
    * @param array|string|int $filter
    * @param int|null $limit
@@ -50,7 +52,21 @@ class Configurations extends \Papaya\Database\Records\Lazy {
    */
   public function load($filter = array(), $limit = NULL, $offset = NULL) {
     $databaseAccess = $this->getDatabaseAccess();
-    $filter = \Papaya\Utility\Text::escapeForPrintf($this->_compileCondition($filter));
+    $prefix = " WHERE ";
+    if (isset($filter['mode_id'])) {
+      $conditionOutput = sprintf(' WHERE vl.viewmode_id = %d', $filter['mode_id']);
+      $conditionData = sprintf(' WHERE vl.datafilter_id = %d', $filter['mode_id']);
+      unset($filter['mode_id']);
+      $prefix = '';
+    } else {
+      $conditionOutput = $conditionData = '';
+    }
+    $conditionOutput = \Papaya\Utility\Text::escapeForPrintf(
+      $conditionOutput.$this->_compileCondition($filter, $prefix)
+    );
+    $conditionData = \Papaya\Utility\Text::escapeForPrintf(
+      $conditionData.$this->_compileCondition($filter, $prefix)
+    );
     $sql = "SELECT vl.view_id,
                     vl.viewmode_id,
                     vl.viewlink_data,
@@ -59,7 +75,7 @@ class Configurations extends \Papaya\Database\Records\Lazy {
                FROM %s vl
                JOIN %s vm ON (vm.viewmode_id = vl.viewmode_id)
                JOIN %s m ON (m.module_guid = vm.module_guid)
-               $filter
+               $conditionOutput
             UNION
             SELECT vl.view_id,
                     vl.datafilter_id viewmode_id,
@@ -69,7 +85,7 @@ class Configurations extends \Papaya\Database\Records\Lazy {
                FROM %s vl
                JOIN %s vm ON (vm.datafilter_id = vl.datafilter_id)
                JOIN %s m ON (m.module_guid = vm.module_guid)
-               $filter";
+               $conditionData";
     $parameters = array(
       $databaseAccess->getTableName(\Papaya\Content\Tables::VIEW_CONFIGURATIONS),
       $databaseAccess->getTableName(\Papaya\Content\Tables::VIEW_MODES),
@@ -78,6 +94,6 @@ class Configurations extends \Papaya\Database\Records\Lazy {
       $databaseAccess->getTableName(\Papaya\Content\Tables::VIEW_DATAFILTERS),
       $databaseAccess->getTableName(\Papaya\Content\Tables::MODULES)
     );
-    return parent::_loadRecords($sql, $parameters, $limit, $offset);
+    return parent::_loadRecords($sql, $parameters, $limit, $offset, $this->_identifierProperties);
   }
 }

--- a/src/system/Papaya/Database/Access.php
+++ b/src/system/Papaya/Database/Access.php
@@ -222,6 +222,21 @@ class Access extends \Papaya\Application\BaseObject {
   }
 
   /**
+   * @param string $identifier
+   * @return string
+   */
+  public function quoteIdentifier($identifier) {
+    $connector = $this->getDatabaseConnector();
+    if (method_exists($connector, 'quoteIdentifier')) {
+      return $connector->quoteIdentifier($identifier);
+    }
+    if (preg_match('([a-zA-Z\\d_])', $identifier)) {
+      return $identifier;
+    }
+    return '_invalid_identifier_';
+  }
+
+  /**
    * Get table name mapper object
    *
    * @param \Papaya\Content\Tables $tables

--- a/src/system/Papaya/Database/Interfaces/Access/Aggregation.php
+++ b/src/system/Papaya/Database/Interfaces/Access/Aggregation.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * papaya CMS
+ *
+ * @copyright 2000-2018 by papayaCMS project - All rights reserved.
+ * @link http://www.papaya-cms.com/
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, version 2
+ *
+ *  You can redistribute and/or modify this script under the terms of the GNU General Public
+ *  License (GPL) version 2, provided that the copyright and license notes, including these
+ *  lines, remain unmodified. papaya is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Papaya\Database\Interfaces\Access;
+
+trait Aggregation {
+
+  use \Papaya\Application\Access\Aggregation;
+
+  /**
+   * Database read uri
+   *
+   * @var string|NULL
+   */
+  private $_databaseURIs = [
+    'read' => NULL,
+    'write' => NULL
+  ];
+
+  /**
+   * Stored database access object
+   *
+   * @var \Papaya\Database\Access
+   */
+  protected $_databaseAccessObject;
+
+  /**
+   * @param NULL|string $read
+   * @param NULL|string $write
+   */
+  public function setDatabaseURIs($read, $write = NULL) {
+    $this->_databaseURIs = [
+      'read' => $read,
+      'write' => $write
+    ];
+  }
+
+  /**
+   * Set database access object
+   *
+   * @param \Papaya\Database\Access $databaseAccessObject
+   */
+  public function setDatabaseAccess(\Papaya\Database\Access $databaseAccessObject) {
+    $this->_databaseAccessObject = $databaseAccessObject;
+  }
+
+  /**
+   * Get database access object
+   *
+   * @return \Papaya\Database\Access
+   */
+  public function getDatabaseAccess() {
+    if (NULL === $this->_databaseAccessObject) {
+      $this->_databaseAccessObject = new \Papaya\Database\Access(
+        $this, $this->_databaseURIs['read'], $this->_databaseURIs['write']
+      );
+      if ($this instanceof \Papaya\Application\Access) {
+        $this->_databaseAccessObject->papaya($this->papaya());
+      }
+    }
+    return $this->_databaseAccessObject;
+  }
+}

--- a/src/system/Papaya/Database/Interfaces/Access/Delegation.php
+++ b/src/system/Papaya/Database/Interfaces/Access/Delegation.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * papaya CMS
+ *
+ * @copyright 2000-2018 by papayaCMS project - All rights reserved.
+ * @link http://www.papaya-cms.com/
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, version 2
+ *
+ *  You can redistribute and/or modify this script under the terms of the GNU General Public
+ *  License (GPL) version 2, provided that the copyright and license notes, including these
+ *  lines, remain unmodified. papaya is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.
+ */
+namespace Papaya\Database\Interfaces\Access;
+
+/**
+ * @method boolean databaseAddField(string $table, array $fieldData)
+ * @method boolean databaseAddIndex(string $table, array $index)
+ * @method boolean databaseChangeField(string $table, array $fieldData)
+ * @method boolean databaseChangeIndex(string $table, array $index)
+ * @method void databaseClose()
+ * @method true databaseCompareFieldStructure(array $xmlField, array $databaseField)
+ * @method boolean databaseCompareKeyStructure()
+ * @method boolean databaseCreateTable(string $tableData, string $tablePrefix)
+ * @method void databaseDebugNextQuery(integer $count = 1)
+ * @method int databaseDeleteRecord(string $table, mixed $filter, mixed $value = NULL)
+ * @method bool databaseDropField(string $table, string $field)
+ * @method bool databaseDropIndex(string $table, string $name)
+ * @method void databaseEnableAbsoluteCount()
+ * @method void databaseEmptyTable(string $table)
+ * @method string databaseEscapeString(mixed $value)
+ * @method string databaseQuoteString(mixed $value)
+ * @method string databaseGetProtocol()
+ * @method string databaseGetSqlSource(string $function, array $params)
+ * @method string databaseGetSqlCondition(array $filter, $value = NULL, $operator = '=')
+ * @method int|string|FALSE databaseInsertRecord(string $table, mixed $idField, array $values = NULL)
+ * @method int|string|FALSE databaseInsertRecords(string $table, array $values)
+ * @method \Papaya\Database\Result|int|FALSE databaseQuery(string $sql, integer $max = NULL, integer $offset = NULL, boolean $readOnly = TRUE)
+ * @method \Papaya\Database\Result|int|FALSE databaseQueryFmt(string $sql, array $values, integer $max = NULL, integer $offset = NULL, boolean $readOnly = TRUE)
+ * @method \Papaya\Database\Result|int|FALSE databaseQueryFmtWrite(string $sql, array $values)
+ * @method \Papaya\Database\Result|int|FALSE databaseQueryWrite(string $sql)
+ * @method int|FALSE databaseUpdateRecord(string $table, array $values, mixed $filter, mixed $value = NULL)
+ * @method array databaseQueryTableNames()
+ * @method array databaseQueryTableStructure(string $tableName)
+ * @method string databaseGetTableName($tableIdentifier, $usePrefix = TRUE)
+ * @method int databaseGetTimestamp()
+ * @method int|string|NULL databaseLastInsertId(string $table, string $idField)
+ */
+trait Delegation {
+  use Aggregation;
+
+  /**
+   * Delegate calls to "database*" methods to the database access object
+   *
+   * @param string $functionName
+   * @param array $arguments
+   * @throws \BadMethodCallException
+   * @return mixed
+   */
+  public function __call($functionName, $arguments) {
+    if (0 === strpos($functionName, 'database')) {
+      $delegateFunction = strtolower($functionName[8]).substr($functionName, 9);
+      $access = $this->getDatabaseAccess();
+      return call_user_func_array(array($access, $delegateFunction), $arguments);
+    }
+    throw new \BadMethodCallException(
+      sprintf(
+        'Invalid function call. Method %s::%s does not exist.',
+        get_class($this),
+        $functionName
+      )
+    );
+  }
+}

--- a/src/system/Papaya/Database/Interfaces/Statement.php
+++ b/src/system/Papaya/Database/Interfaces/Statement.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * papaya CMS
+ *
+ * @copyright 2000-2018 by papayaCMS project - All rights reserved.
+ * @link http://www.papaya-cms.com/
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, version 2
+ *
+ *  You can redistribute and/or modify this script under the terms of the GNU General Public
+ *  License (GPL) version 2, provided that the copyright and license notes, including these
+ *  lines, remain unmodified. papaya is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Papaya\Database\Interfaces;
+
+interface Statement {
+
+  /**
+   * @return string
+   */
+  public function getSQL();
+
+  /**
+   * @return string
+   */
+  public function __toString();
+}

--- a/src/system/Papaya/Database/Statement/Formatted.php
+++ b/src/system/Papaya/Database/Statement/Formatted.php
@@ -19,15 +19,24 @@ namespace Papaya\Database\Statement {
 
     private $_sql;
     private $_parameters;
+    private $_databaseAccess;
 
     public function __construct(\Papaya\Database\Access $databaseAccess, $sql, array $parameters = []) {
-      $this->setDatabaseAccess($databaseAccess);
+      $this->_databaseAccess = $databaseAccess;
       $this->_sql = $sql;
       $this->_parameters = $parameters;
     }
 
     public function __toString() {
-      return \vsprintf($this->_sql, $this->_parameters);
+      return \vsprintf(
+        $this->_sql,
+        array_map(
+          function($value) {
+            return $this->_databaseAccess->escapeString($value);
+          },
+          $this->_parameters
+        )
+      );
     }
   }
 }

--- a/src/system/Papaya/Database/Statement/Formatted.php
+++ b/src/system/Papaya/Database/Statement/Formatted.php
@@ -13,16 +13,21 @@
  *  FOR A PARTICULAR PURPOSE.
  */
 
-namespace Papaya\Database;
+namespace Papaya\Database\Statement {
 
-/**
- * Papaya Database Object, superclass for classes with database access
- *
- * @package Papaya-Library
- * @subpackage Database
- */
-class BaseObject
-  implements \Papaya\Application\Access, Interfaces\Access {
+  class Formatted {
 
-  use Interfaces\Access\Delegation;
+    private $_sql;
+    private $_parameters;
+
+    public function __construct(\Papaya\Database\Access $databaseAccess, $sql, array $parameters = []) {
+      $this->setDatabaseAccess($databaseAccess);
+      $this->_sql = $sql;
+      $this->_parameters = $parameters;
+    }
+
+    public function __toString() {
+      return \vsprintf($this->_sql, $this->_parameters);
+    }
+  }
 }

--- a/src/system/Papaya/Database/Statement/Prepared.php
+++ b/src/system/Papaya/Database/Statement/Prepared.php
@@ -33,7 +33,8 @@ namespace Papaya\Database\Statement {
    *
    * @package Papaya\Database\Statement
    */
-  class Prepared {
+  class Prepared
+    implements \Papaya\Database\Interfaces\Statement {
 
     /**
      * @var \Papaya\Database\Access

--- a/src/system/Papaya/Database/Statement/Prepared.php
+++ b/src/system/Papaya/Database/Statement/Prepared.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * papaya CMS
+ *
+ * @copyright 2000-2018 by papayaCMS project - All rights reserved.
+ * @link http://www.papaya-cms.com/
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, version 2
+ *
+ *  You can redistribute and/or modify this script under the terms of the GNU General Public
+ *  License (GPL) version 2, provided that the copyright and license notes, including these
+ *  lines, remain unmodified. papaya is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Papaya\Database\Statement {
+
+  /**
+   * A client side prepared statement. All parameters have to be named.
+   * Parameter type specific methods have to be used to add them. The
+   * parameter names are prefixed with a colon in the SQL. Unlike
+   * server side prepared statements it allows for list parameters and
+   * table names as well.
+   *
+   * Example:
+   *
+   *  $statement = new Prepared(
+   *    $databaseAccess
+   *    'SELECT * FROM :tableOne WHERE id IN :IDs'
+   *  );
+   *  $statement->addTableName('tableOne', 'a_table');
+   *  $statement->addIntList('IDs', [1,2,3]);
+   *
+   * @package Papaya\Database\Statement
+   */
+  class Prepared {
+
+    /**
+     * @var \Papaya\Database\Access
+     */
+    private $_databaseAccess;
+    /**
+     * @var string
+     */
+    private $_sql;
+    /**
+     * @var array
+     */
+    private $_parameters = [];
+
+    public function __construct(\Papaya\Database\Access $databaseAccess, $sql) {
+      $this->_databaseAccess = $databaseAccess;
+      $this->_sql = $sql;
+    }
+
+    public function __toString() {
+      try {
+        return $this->getSQL();
+      } catch (\Exception $e) {
+        return '';
+      }
+    }
+
+    public function getSQL() {
+      $quoteCharacters = ["'", '"', '`'];
+      $patterns = [];
+      foreach ($quoteCharacters as $quoteCharacter) {
+        $patterns[] = sprintf('(?:%1$s(?:[^%1$s]|\\\\%1$s|%1$s{2})*%1$s)', $quoteCharacter);
+      }
+      $pattern = '(('.implode('|', $patterns).'))';
+      $parts = \preg_split($pattern, $this->_sql, -1, PREG_SPLIT_DELIM_CAPTURE);
+      $result = '';
+      foreach ($parts as $part) {
+        if (\in_array(\substr($part, 0, 1), $quoteCharacters, TRUE)) {
+          $result .= $part;
+          continue;
+        }
+        $result .= \preg_replace_callback(
+          '(:(?<name>[a-zA-Z][a-zA-Z\d_]*))',
+          function($match) {
+            $parameterName = \strtolower($match['name']);
+            if (!\array_key_exists($parameterName, $this->_parameters)) {
+              throw new \LogicException(\sprintf('Unknown parameter name: %s', $parameterName));
+            }
+            return $this->encodeParameterValue(
+              $this->_parameters[$parameterName]['value'],
+              $this->_parameters[$parameterName]['filter']
+            );
+          },
+          $part
+        );
+      }
+      return $result;
+    }
+
+    /**
+     * @param mixed $value
+     * @param callable $filterFunction
+     * @return string
+     */
+    private function encodeParameterValue($value, callable $filterFunction) {
+      if (\is_array($value) || $value instanceof \Traversable) {
+        $encodedValues = [];
+        foreach ($value as $subValue) {
+          if (NULL === $subValue) {
+            continue;
+          }
+          if (\is_scalar($subValue)) {
+            $encodedValues[] = $filterFunction($subValue);
+          } elseif (\is_object($subValue) && method_exists($subValue, '__toString')) {
+            $encodedValues[] = $filterFunction((string)$subValue);
+          } else {
+            throw new \UnexpectedValueException(
+              'Parameter list values need to be scalars or string castable.'
+            );
+          }
+        }
+        return '('.\implode(', ', $encodedValues).')';
+      }
+      return $filterFunction($value);
+    }
+
+    /**
+     * @param string $parameterName
+     * @param mixed $value
+     * @param callable $filterFunction
+     */
+    private function addValue($parameterName, $value, callable $filterFunction) {
+      $parameterName = $this->validateParameterName($parameterName);
+      $this->_parameters[$parameterName] = ['value' => $value, 'filter' => $filterFunction];
+    }
+
+    /**
+     * @param string $parameterName
+     * @param mixed $values
+     * @param callable $filterFunction
+     */
+    private function addValueList($parameterName, $values, callable $filterFunction) {
+      $this->addValue(
+        $parameterName,
+        \is_array($values) || $values instanceof \Traversable ? $values : [$values],
+        $filterFunction
+      );
+    }
+
+    /**
+     * Throw exception for invalid parameter names and bound parameters
+     *
+     * @param string $parameterName
+     * @return string
+     */
+    private function validateParameterName($parameterName) {
+      $parameterName = \strtolower($parameterName);
+      if (!\preg_match('(^[a-z][a-z\d_]*$)D', $parameterName)) {
+        throw new \InvalidArgumentException(
+          'Parameter name has to start with a letter and can only contain letters, digits and underscores.'
+        );
+      }
+      if (\array_key_exists($parameterName, $this->_parameters)) {
+        throw new \LogicException(\sprintf('Duplicate parameter name: %s', $parameterName));
+      }
+      return $parameterName;
+    }
+
+    /**
+     * @param string $parameterName
+     */
+    public function addNull($parameterName) {
+      $this->addValue($parameterName, NULL, function() { return 'NULL'; });
+    }
+
+    /**
+     * @param string $parameterName
+     * @param string $value
+     */
+    public function addString($parameterName, $value) {
+      $this->addValue(
+        $parameterName,
+        $value,
+        function($value) {
+          return $this->_databaseAccess->quoteString((string)$value);
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param string[]|string $values
+     */
+    public function addStringList($parameterName, $values) {
+      $this->addValueList(
+        $parameterName,
+        $values,
+        function($value) {
+          return $this->_databaseAccess->quoteString((string)$value);
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param int $value
+     */
+    public function addInt($parameterName, $value) {
+      $this->addValue(
+        $parameterName,
+        $value,
+        function($value) {
+          return (string)(int)$value;
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param int[]|int $values
+     */
+    public function addIntList($parameterName, $values) {
+      $this->addValueList(
+        $parameterName,
+        $values,
+        function($value) {
+          return (string)(int)$value;
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param float $value
+     * @param int $decimals
+     */
+    public function addFloat($parameterName, $value, $decimals = 8) {
+      $this->addValue(
+        $parameterName,
+        $value,
+        function($value) use ($decimals) {
+          return number_format((float)$value, $decimals);
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param bool $value
+     */
+    public function addBool($parameterName, $value) {
+      $this->addValue(
+        $parameterName,
+        $value,
+        function($value) {
+          return $value ? 'true' : 'false';
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @param string $tableName
+     * @param bool $usePrefix
+     */
+    public function addTableName($parameterName, $tableName, $usePrefix = TRUE) {
+      $this->addValue(
+        $parameterName,
+        $tableName,
+        function($tableName) use($usePrefix) {
+          return $this->_databaseAccess->quoteIdentifier(
+            $this->_databaseAccess->getTableName($tableName, $usePrefix)
+          );
+        }
+      );
+    }
+
+    /**
+     * @param string $parameterName
+     * @return bool
+     */
+    public function has($parameterName) {
+      $parameterName = strtolower($parameterName);
+      return \array_key_exists($parameterName, $this->_parameters);
+    }
+
+    /**
+     * @param string $parameterName
+     */
+    public function remove($parameterName) {
+      $parameterName = strtolower($parameterName);
+      if (\array_key_exists($parameterName, $this->_parameters)) {
+        unset($this->_parameters[$parameterName]);
+      }
+    }
+  }
+}

--- a/src/system/Papaya/Database/Statement/Prepared.php
+++ b/src/system/Papaya/Database/Statement/Prepared.php
@@ -165,14 +165,17 @@ namespace Papaya\Database\Statement {
 
     /**
      * @param string $parameterName
+     * @return $this
      */
     public function addNull($parameterName) {
       $this->addValue($parameterName, NULL, function() { return 'NULL'; });
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param string $value
+     * @return $this
      */
     public function addString($parameterName, $value) {
       $this->addValue(
@@ -182,11 +185,13 @@ namespace Papaya\Database\Statement {
           return $this->_databaseAccess->quoteString((string)$value);
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param string[]|string $values
+     * @return $this
      */
     public function addStringList($parameterName, $values) {
       $this->addValueList(
@@ -196,11 +201,13 @@ namespace Papaya\Database\Statement {
           return $this->_databaseAccess->quoteString((string)$value);
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param int $value
+     * @return $this
      */
     public function addInt($parameterName, $value) {
       $this->addValue(
@@ -210,11 +217,13 @@ namespace Papaya\Database\Statement {
           return (string)(int)$value;
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param int[]|int $values
+     * @return $this
      */
     public function addIntList($parameterName, $values) {
       $this->addValueList(
@@ -224,12 +233,14 @@ namespace Papaya\Database\Statement {
           return (string)(int)$value;
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param float $value
      * @param int $decimals
+     * @return $this
      */
     public function addFloat($parameterName, $value, $decimals = 8) {
       $this->addValue(
@@ -239,11 +250,13 @@ namespace Papaya\Database\Statement {
           return number_format((float)$value, $decimals);
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param bool $value
+     * @return $this
      */
     public function addBool($parameterName, $value) {
       $this->addValue(
@@ -253,12 +266,14 @@ namespace Papaya\Database\Statement {
           return $value ? 'true' : 'false';
         }
       );
+      return $this;
     }
 
     /**
      * @param string $parameterName
      * @param string $tableName
      * @param bool $usePrefix
+     * @return $this
      */
     public function addTableName($parameterName, $tableName, $usePrefix = TRUE) {
       $this->addValue(
@@ -270,6 +285,7 @@ namespace Papaya\Database\Statement {
           );
         }
       );
+      return $this;
     }
 
     /**

--- a/src/system/Papaya/Filter/Factory.php
+++ b/src/system/Papaya/Filter/Factory.php
@@ -56,6 +56,14 @@ class Factory implements \IteratorAggregate {
    */
   private static $_profiles;
 
+  private static $_renamed = [
+    'IsNotXml' => 'IsNotXML',
+    'IsUrl' => 'IsURL',
+    'IsUrlHost' => 'IsURLHost',
+    'IsUrlHttp' => 'IsURLWeb',
+    'IsXml' => 'IsXML'
+  ];
+
   /**
    * Returns an ArrayIterator for the available profiles. The
    * profiles need to be defined in the \Papaya\Filter interface.
@@ -110,9 +118,14 @@ class Factory implements \IteratorAggregate {
     $key = strtolower($name);
     $namespace = __CLASS__.'\\Profile\\';
     if (isset(self::$_profiles[$key])) {
-      return $namespace.\Papaya\Utility\Text\Identifier::toCamelCase(self::$_profiles[$key], TRUE);
+      $class = ucfirst(self::$_profiles[$key]);
+    } else {
+      $class = ucfirst($name);
     }
-    return $namespace.\Papaya\Utility\Text\Identifier::toCamelCase($name, TRUE);
+    if (isset(self::$_renamed[$class])) {
+      $class = self::$_renamed[$class];
+    }
+    return $namespace.$class;
   }
 
   /**
@@ -161,7 +174,7 @@ class Factory implements \IteratorAggregate {
   /**
    * Get the filter using the specified profile, internal static call
    *
-   * @param $profile
+   * @param string|Factory\Profile $profile
    * @param bool $mandatory
    * @param mixed $options
    * @return \Papaya\Filter|\Papaya\Filter\LogicalOr

--- a/src/system/Papaya/Message/Display.php
+++ b/src/system/Papaya/Message/Display.php
@@ -21,14 +21,14 @@ namespace Papaya\Message;
  * @subpackage Messages
  */
 class Display
-  implements \Papaya\Message\Displayable {
+  implements Displayable {
 
   /**
    * Message type
    *
    * @var integer
    */
-  protected $_type = \Papaya\Message::SEVERITY_INFO;
+  protected $_severity = \Papaya\Message::SEVERITY_INFO;
 
   /**
    * Message text
@@ -42,30 +42,30 @@ class Display
    *
    * @var array
    */
-  protected $_allowedTypes = array(
+  private $_possibleSeverities = array(
     \Papaya\Message::SEVERITY_INFO,
     \Papaya\Message::SEVERITY_WARNING,
     \Papaya\Message::SEVERITY_ERROR
   );
 
   /**
-   * @param integer $type
+   * @param integer $severity
    * @param string|\Papaya\UI\Text $message
    */
-  public function __construct($type, $message) {
-    $this->_isValidType($type);
-    $this->_type = $type;
+  public function __construct($severity, $message) {
+    $this->_isValidSeverity($severity);
+    $this->_severity = $severity;
     $this->_message = $message;
   }
 
   /**
    * check if the given type is valid for this kind of messages
    *
-   * @param int $type
+   * @param int $severity
    * @return bool
    */
-  protected function _isValidType($type) {
-    if (in_array($type, $this->_allowedTypes, FALSE)) {
+  private function _isValidSeverity($severity) {
+    if (in_array($severity, $this->_possibleSeverities, FALSE)) {
       return TRUE;
     }
     throw new \InvalidArgumentException('Invalid message type.');
@@ -77,7 +77,7 @@ class Display
    * @return integer
    */
   public function getType() {
-    return $this->_type;
+    return $this->_severity;
   }
 
   /**
@@ -86,7 +86,7 @@ class Display
    * @return integer
    */
   public function getSeverity() {
-    return $this->_type;
+    return $this->_severity;
   }
 
   /**

--- a/src/system/Papaya/Message/Manager.php
+++ b/src/system/Papaya/Message/Manager.php
@@ -15,6 +15,8 @@
 
 namespace Papaya\Message;
 
+use Papaya\Message;
+
 /**
  * Papaya Message Manager, central message manager, handles the dispatchers
  *
@@ -65,6 +67,30 @@ class Manager extends \Papaya\Application\BaseObject {
    */
   public function display($severity, $messageText, array $parameters = NULL) {
     $this->dispatch(new Display\Translated($severity, $messageText, $parameters ?: []));
+  }
+
+  /**
+   * @param string $messageText
+   * @param array|NULL $parameters
+   */
+  public function displayInfo($messageText, array $parameters = NULL) {
+    $this->display(Message::SEVERITY_INFO, $messageText, $parameters ?: []);
+  }
+
+  /**
+   * @param string $messageText
+   * @param array|NULL $parameters
+   */
+  public function displayWarning($messageText, array $parameters = NULL) {
+    $this->display(Message::SEVERITY_WARNING, $messageText, $parameters ?: []);
+  }
+
+  /**
+   * @param string $messageText
+   * @param array|NULL $parameters
+   */
+  public function displayError($messageText, array $parameters = NULL) {
+    $this->display(Message::SEVERITY_ERROR, $messageText, $parameters ?: []);
   }
 
   /**

--- a/src/system/Papaya/Message/Manager.php
+++ b/src/system/Papaya/Message/Manager.php
@@ -14,6 +14,7 @@
  */
 
 namespace Papaya\Message;
+
 /**
  * Papaya Message Manager, central message manager, handles the dispatchers
  *
@@ -58,13 +59,12 @@ class Manager extends \Papaya\Application\BaseObject {
   }
 
   /**
-   * Display a message to the user
-   *
-   * @param $severity
-   * @param $text
+   * @param int $severity
+   * @param string $messageText
+   * @param array|NULL $parameters
    */
-  public function display($severity, $text) {
-    $this->dispatch(new Display($severity, $text));
+  public function display($severity, $messageText, array $parameters = NULL) {
+    $this->dispatch(new Display\Translated($severity, $messageText, $parameters ?: []));
   }
 
   /**

--- a/src/system/Papaya/UI/Content/Teasers.php
+++ b/src/system/Papaya/UI/Content/Teasers.php
@@ -156,7 +156,7 @@ class Teasers extends \Papaya\UI\Control {
         $parent,
         [],
         $this->viewConfigurations()->offsetGet(
-          [[$pageData['view_id'], $pageData['viewmode_id'], \Papaya\Content\View\Configurations::TYPE_OUTPUT]]
+          [$pageData['view_id'], $pageData['viewmode_id'], \Papaya\Content\View\Configurations::TYPE_OUTPUT]
         )
       );
     }

--- a/src/system/Papaya/UI/Content/Teasers.php
+++ b/src/system/Papaya/UI/Content/Teasers.php
@@ -152,7 +152,7 @@ class Teasers extends \Papaya\UI\Control {
       );
       $page->papaya($this->papaya());
       $page->assign($pageData);
-      if ($pageData['viewmode_id'] === -1) {
+      if (NULL !== $pageData['viewmode_id']) {
         $viewData = $this->viewConfigurations()->offsetGet(
           [$pageData['view_id'], $pageData['viewmode_id'], \Papaya\Content\View\Configurations::TYPE_OUTPUT]
         );

--- a/src/system/Papaya/UI/Content/Teasers.php
+++ b/src/system/Papaya/UI/Content/Teasers.php
@@ -98,7 +98,11 @@ class Teasers extends \Papaya\UI\Control {
         new \Papaya\Iterator\ArrayMapper($this->pages(), 'viewmode_id'), FALSE
       );
       $this->_viewConfigurations->activateLazyLoad(
-        ['id' => $viewIds, 'mode_id' => $this->papaya()->request->modeId]
+        [
+          'id' => $viewIds,
+          'mode_id' => $this->papaya()->request->modeId,
+          'type' =>  \Papaya\Content\View\Configurations::TYPE_OUTPUT
+        ]
       );
     }
     return $this->_viewConfigurations;
@@ -151,7 +155,9 @@ class Teasers extends \Papaya\UI\Control {
       $page->appendQuoteTo(
         $parent,
         [],
-        $this->viewConfigurations()->offsetGet([[$pageData['view_id'], $pageData['viewmode_id']]])
+        $this->viewConfigurations()->offsetGet(
+          [[$pageData['view_id'], $pageData['viewmode_id'], \Papaya\Content\View\Configurations::TYPE_OUTPUT]]
+        )
       );
     }
   }

--- a/src/system/Papaya/UI/Content/Teasers.php
+++ b/src/system/Papaya/UI/Content/Teasers.php
@@ -95,7 +95,7 @@ class Teasers extends \Papaya\UI\Control {
       $this->_viewConfigurations = new \Papaya\Content\View\Configurations();
       $this->_viewConfigurations->papaya($this->papaya());
       $viewIds = iterator_to_array(
-        new \Papaya\Iterator\ArrayMapper($this->pages(), 'viewmode_id'), FALSE
+        new \Papaya\Iterator\ArrayMapper($this->pages(), 'view_id'), FALSE
       );
       $this->_viewConfigurations->activateLazyLoad(
         [
@@ -152,13 +152,14 @@ class Teasers extends \Papaya\UI\Control {
       );
       $page->papaya($this->papaya());
       $page->assign($pageData);
-      $page->appendQuoteTo(
-        $parent,
-        [],
-        $this->viewConfigurations()->offsetGet(
+      if ($pageData['viewmode_id'] === -1) {
+        $viewData = $this->viewConfigurations()->offsetGet(
           [$pageData['view_id'], $pageData['viewmode_id'], \Papaya\Content\View\Configurations::TYPE_OUTPUT]
-        )
-      );
+        );
+      } else {
+        $viewData = ['id' => -1, 'mode_id' => -1, 'type' => \Papaya\Content\View\Configurations::TYPE_OUTPUT];
+      }
+      $page->appendQuoteTo($parent, [], $viewData);
     }
   }
 

--- a/src/system/papaya_installer.php
+++ b/src/system/papaya_installer.php
@@ -227,7 +227,7 @@ class papaya_installer extends base_db {
           'login' => $dialog->data['login']
         )
       );
-      if (trim($dialog->data['password']) != '') {
+      if ('' !== trim($dialog->data['password'])) {
         $this->sessionParams['installer_basic_options']['password_hash'] =
           $this->passwordApi()->getPasswordHash($dialog->data['password']);
       }
@@ -235,9 +235,8 @@ class papaya_installer extends base_db {
     } elseif ($dialog->isSubmitted()) {
       $this->papaya()->messages->display(
         \Papaya\Message::SEVERITY_ERROR,
-        'Please check your intput in the following fields: '.implode(
-          ', ', $dialog->errors()->getSourceCaptions()
-        )
+        'Please check your input in the following fields: %s',
+        [implode(', ', $dialog->errors()->getSourceCaptions()]
       );
     }
     $this->layout->add($this->getXMLDefaults());

--- a/src/system/papaya_parser.php
+++ b/src/system/papaya_parser.php
@@ -170,7 +170,7 @@ class papaya_parser extends base_db {
   * @return string
   */
   function parse($data, $lngId) {
-    \Papaya\Utility\File\Constraints::assertString($data);
+    \Papaya\Utility\Constraints::assertString($data);
     $this->data = $data;
     if (defined('PAPAYA_ADMIN_PAGE') && PAPAYA_ADMIN_PAGE) {
       $this->lngId = $this->papaya()->administrationLanguage->id;

--- a/tests/system/Papaya/Administration/Community/Users/Roster/DialogTest.php
+++ b/tests/system/Papaya/Administration/Community/Users/Roster/DialogTest.php
@@ -171,14 +171,24 @@ class DialogTest extends \Papaya\TestCase {
   }
 
   /**
-   * @covers \Papaya\Administration\Community\Users\Roster\Dialog::createUserItem
+   * @covers \Papaya\Administration\Community\Users\Roster\Dialog
    */
-  public function testCreateUserItem() {
+  public function testCreatesListItemForUser() {
+    $users = $this->createMock(\Papaya\Content\Community\Users::class);
+    $users
+      ->expects($this->any())
+      ->method('getIterator')
+      ->willReturn(
+        new \ArrayIterator(
+          [
+             ['id' => 42, 'caption' => 'test']
+          ]
+        )
+      );
+
     $dialog = new Dialog();
     $dialog->papaya($this->mockPapaya()->application());
-    $dialog->createUserItem(
-      new \stdClass, $dialog->listview()->items, array('id' => 42, 'caption' => 'test')
-    );
+    $dialog->users($users);
     $this->assertXmlStringEqualsXmlString(
     /** @lang XML */
       '<listitem title="test" href="http://www.test.tld/test.html?page=1&amp;user_id=42"/>',
@@ -229,14 +239,25 @@ class DialogTest extends \Papaya\TestCase {
    * @covers \Papaya\Administration\Community\Users\Roster\Dialog::setParameterNameMapping
    */
   public function testSetParameterNameMapping() {
+    $users = $this->createMock(\Papaya\Content\Community\Users::class);
+    $users
+      ->expects($this->any())
+      ->method('getIterator')
+      ->willReturn(
+        new \ArrayIterator(
+          [
+             ['id' => 42, 'caption' => 'test']
+          ]
+        )
+      );
+
     $dialog = new Dialog();
+    $dialog->papaya($this->mockPapaya()->application());
+    $dialog->users($users);
     $dialog->setParameterNameMapping('user', 'surfer_id');
     $dialog->setParameterNameMapping('filter', 'search');
     $dialog->setParameterNameMapping('page', 'offset_page');
     $dialog->papaya($this->mockPapaya()->application());
-    $dialog->createUserItem(
-      new \stdClass, $dialog->listview()->items, array('id' => 42, 'caption' => 'test')
-    );
     $this->assertXmlStringEqualsXmlString(
     /** @lang XML */
       '<listitem title="test" href="http://www.test.tld/test.html?offset_page=1&amp;surfer_id=42"/>',

--- a/tests/system/Papaya/Administration/Pages/Dependency/Command/ChangeTest.php
+++ b/tests/system/Papaya/Administration/Pages/Dependency/Command/ChangeTest.php
@@ -303,8 +303,8 @@ class ChangeTest extends \Papaya\TestCase {
     $messages = $this->createMock(\Papaya\Message\Manager::class);
     $messages
       ->expects($this->once())
-      ->method('dispatch')
-      ->with($this->isInstanceOf(\Papaya\Message\Display\Translated::class));
+      ->method('display')
+      ->with(\Papaya\Message::SEVERITY_INFO, 'Dependency saved.');
     $application = $this->mockPapaya()->application(
       array(
         'Messages' => $messages
@@ -334,8 +334,8 @@ class ChangeTest extends \Papaya\TestCase {
     $messages = $this->createMock(\Papaya\Message\Manager::class);
     $messages
       ->expects($this->once())
-      ->method('dispatch')
-      ->with($this->isInstanceOf(\Papaya\Message\Display\Translated::class));
+      ->method('display')
+      ->with(\Papaya\Message::SEVERITY_ERROR, 'Invalid input. Please check the following fields: "%s".', ['field']);
     $application = $this->mockPapaya()->application(
       array(
         'Messages' => $messages

--- a/tests/system/Papaya/Content/View/ConfigurationsTest.php
+++ b/tests/system/Papaya/Content/View/ConfigurationsTest.php
@@ -35,7 +35,7 @@ class ConfigurationsTest extends \Papaya\TestCase {
             'viewmode_id' => '123',
             'viewlink_data' => 'DATA',
             'module_guid' => '123456789012345678901234567890ab',
-            'module_type' => 'page'
+            'module_type' => 'output'
           ),
           FALSE
         )
@@ -65,12 +65,12 @@ class ConfigurationsTest extends \Papaya\TestCase {
     );
     $this->assertEquals(
       array(
-        array(
+        '42|123|output' => array(
           'id' => '42',
           'mode_id' => 123,
           'options' => 'DATA',
           'module_guid' => '123456789012345678901234567890ab',
-          'type' => 'page'
+          'type' => 'output'
         )
       ),
       iterator_to_array($list)

--- a/tests/system/Papaya/Database/Statement/FormattedTest.php
+++ b/tests/system/Papaya/Database/Statement/FormattedTest.php
@@ -15,32 +15,29 @@
 
 namespace Papaya\Database\Statement {
 
-  class Formatted
-    implements \Papaya\Database\Interfaces\Statement {
+  require_once __DIR__.'/../../../../bootstrap.php';
 
-    private $_sql;
-    private $_parameters;
-    private $_databaseAccess;
+  /**
+   * @covers \Papaya\Database\Statement\Formatted
+   */
+  class FormattedTest extends \Papaya\TestCase {
 
-    public function __construct(\Papaya\Database\Access $databaseAccess, $sql, array $parameters = []) {
-      $this->_databaseAccess = $databaseAccess;
-      $this->_sql = $sql;
-      $this->_parameters = $parameters;
-    }
+    public function testGetSQLInsertsEscapedParameters() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $databaseAccess
+        ->expects($this->once())
+        ->method('escapeString')
+        ->with('ab123')
+        ->willReturn('ab123');
 
-    public function __toString() {
-      return $this->getSQL();
-    }
-
-    public function getSQL() {
-      return \vsprintf(
-        $this->_sql,
-        array_map(
-          function($value) {
-            return $this->_databaseAccess->escapeString($value);
-          },
-          $this->_parameters
-        )
+      $statement = new Formatted(
+        $databaseAccess,
+        "SELECT * FROM test WHERE id = '%s'",
+        ['ab123']
+      );
+      $this->assertEquals(
+        "SELECT * FROM test WHERE id = 'ab123'",
+        (string)$statement
       );
     }
   }

--- a/tests/system/Papaya/Database/Statement/PreparedTest.php
+++ b/tests/system/Papaya/Database/Statement/PreparedTest.php
@@ -34,8 +34,9 @@ namespace Papaya\Database\Statement {
         $databaseAccess,
         'SELECT * FROM :a_table WHERE id = :id'
       );
-      $statement->addTableName('a_table', 'test');
-      $statement->addString('id', 'ab123');
+      $statement
+        ->addTableName('a_table', 'test')
+        ->addString('id', 'ab123');
 
       $this->assertEquals(
         "SELECT * FROM table_test WHERE id = 'ab123'",
@@ -61,8 +62,9 @@ namespace Papaya\Database\Statement {
         $databaseAccess,
         'SELECT * FROM :a_table WHERE id IN :id'
       );
-      $statement->addTableName('a_table', 'test');
-      $statement->addStringList('id', ['ab123', 'ef456']);
+      $statement
+        ->addTableName('a_table', 'test')
+        ->addStringList('id', ['ab123', 'ef456']);
 
       $this->assertEquals(
         "SELECT * FROM table_test WHERE id IN ('ab123', 'ef456')",
@@ -137,8 +139,9 @@ namespace Papaya\Database\Statement {
         $databaseAccess,
         'INSERT INTO test VALUES (:field1, :field2)'
       );
-      $statement->addInt('field1', 21);
-      $statement->addNull('field2');
+      $statement
+        ->addInt('field1', 21)
+        ->addNull('field2');
 
       $this->assertEquals(
         'INSERT INTO test VALUES (21, NULL)',

--- a/tests/system/Papaya/Database/Statement/PreparedTest.php
+++ b/tests/system/Papaya/Database/Statement/PreparedTest.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * papaya CMS
+ *
+ * @copyright 2000-2018 by papayaCMS project - All rights reserved.
+ * @link http://www.papaya-cms.com/
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, version 2
+ *
+ *  You can redistribute and/or modify this script under the terms of the GNU General Public
+ *  License (GPL) version 2, provided that the copyright and license notes, including these
+ *  lines, remain unmodified. papaya is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Papaya\Database\Statement {
+
+  require_once __DIR__.'/../../../../bootstrap.php';
+
+  /**
+   * @covers \Papaya\Database\Statement\Prepared
+   */
+  class PreparedTest extends \Papaya\TestCase {
+
+    public function testGetSQLWithTableAndStringParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $databaseAccess
+        ->expects($this->once())
+        ->method('quoteString')
+        ->with('ab123')
+        ->willReturn("'ab123'");
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM :a_table WHERE id = :id'
+      );
+      $statement->addTableName('a_table', 'test');
+      $statement->addString('id', 'ab123');
+
+      $this->assertEquals(
+        "SELECT * FROM table_test WHERE id = 'ab123'",
+        (string)$statement
+      );
+    }
+
+    public function testGetSQLWithTableAndStringListParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $databaseAccess
+        ->expects($this->exactly(2))
+        ->method('quoteString')
+        ->will(
+          $this->returnValueMap(
+            [
+              ['ab123', "'ab123'"],
+              ['ef456', "'ef456'"]
+            ]
+          )
+        );
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM :a_table WHERE id IN :id'
+      );
+      $statement->addTableName('a_table', 'test');
+      $statement->addStringList('id', ['ab123', 'ef456']);
+
+      $this->assertEquals(
+        "SELECT * FROM table_test WHERE id IN ('ab123', 'ef456')",
+        (string)$statement
+      );
+    }
+
+    public function testGetSQLWithFloatParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM test WHERE field > :number'
+      );
+      $statement->addFloat('number', 42.21, 4);
+
+      $this->assertEquals(
+        'SELECT * FROM test WHERE field > 42.2100',
+        (string)$statement
+      );
+    }
+
+    public function testGetSQLWithIntParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM test WHERE field > :number'
+      );
+      $statement->addInt('number', 42);
+
+      $this->assertEquals(
+        'SELECT * FROM test WHERE field > 42',
+        (string)$statement
+      );
+    }
+
+    public function testGetSQLWithIntListParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM test WHERE id IN :IDs'
+      );
+      $statement->addIntList('IDs', [21, 42]);
+
+      $this->assertEquals(
+        'SELECT * FROM test WHERE id IN (21, 42)',
+        $statement->getSQL()
+      );
+    }
+
+    public function testGetSQLWithBoolParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'SELECT * FROM test WHERE field IS :bool'
+      );
+      $statement->addBool('bool', true);
+
+      $this->assertEquals(
+        'SELECT * FROM test WHERE field IS true',
+        (string)$statement
+      );
+    }
+
+    public function testGetSQLWithNULLParameter() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        'INSERT INTO test VALUES (:field1, :field2)'
+      );
+      $statement->addInt('field1', 21);
+      $statement->addNull('field2');
+
+      $this->assertEquals(
+        'INSERT INTO test VALUES (21, NULL)',
+        $statement->getSQL()
+      );
+    }
+
+    public function testPlaceholdersInsideStringLiteralAreNotReplaced() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        "INSERT INTO test VALUES (:number, ':number')"
+      );
+      $statement->addInt('number', 21);
+
+      $this->assertEquals(
+        "INSERT INTO test VALUES (21, ':number')",
+        $statement->getSQL()
+      );
+    }
+
+    public function testUnknownParameterThrowsException() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared(
+        $databaseAccess,
+        ':unknown'
+      );
+
+      $this->expectException(\LogicException::class);
+      $this->expectExceptionMessage('Unknown parameter name: unknown');
+      $statement->getSQL();
+    }
+
+    public function testNULLInListIsIgnored() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared($databaseAccess, ':numbers');
+      $statement->addIntList('numbers', [21, NULL, 42]);
+
+      $this->assertEquals(
+        '(21, 42)',
+        $statement->getSQL()
+      );
+    }
+
+    public function testArrayInListThrowsException() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared($databaseAccess, ':numbers');
+      $statement->addIntList('numbers', [21, [42]]);
+
+      $this->expectException(\UnexpectedValueException::class);
+      $this->expectExceptionMessage('Parameter list values need to be scalars or string castable.');
+      $statement->getSQL();
+    }
+
+    public function testObjectInListIsCastToString() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $databaseAccess
+        ->expects($this->atLeastOnce())
+        ->method('quoteString')
+        ->will(
+          $this->returnValueMap(
+             [
+               ['21', "'21'"],
+               ['string_value', "'string_value'"],
+             ]
+          )
+        );
+
+      $stringObject = $this->createMock(\Papaya\Text\UTF8String::class);
+      $stringObject
+        ->expects($this->once())
+        ->method('__toString')
+        ->willReturn('string_value');
+
+      $statement = new Prepared($databaseAccess, ':ids');
+      $statement->addStringList('ids', [21, $stringObject]);
+
+      $this->assertEquals(
+        "('21', 'string_value')",
+        $statement->getSQL()
+      );
+    }
+
+    public function testHasExpectingTrue() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared($databaseAccess, '');
+      $statement->addInt('number', 21);
+
+      $this->assertTrue($statement->has('number'));
+      $this->assertTrue($statement->has('NUMBER'));
+    }
+
+    public function testHasAfterRemoveExpectingFalse() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+
+      $statement = new Prepared($databaseAccess, '');
+      $statement->addInt('number', 21);
+      $statement->remove('Number');
+
+      $this->assertFalse($statement->has('number'));
+    }
+
+    /**
+     * @param string $parameterName
+     * @testWith
+     *  [""]
+     *  ["42"]
+     *  ["foo bar"]
+     */
+    public function testInvalidParameterNameThrowsException($parameterName) {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $statement = new Prepared($databaseAccess, '');
+
+      $this->expectException(\InvalidArgumentException::class);
+      $this->expectExceptionMessage(
+        'Parameter name has to start with a letter and can only contain letters, digits and underscores.'
+      );
+
+      $statement->addInt($parameterName, 0);
+    }
+
+    public function testDuplicateParameterNameThrowsException() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $statement = new Prepared($databaseAccess, '');
+      $statement->addInt('field', 0);
+
+      $this->expectException(\LogicException::class);
+      $this->expectExceptionMessage(
+        'Duplicate parameter name: field'
+      );
+
+      $statement->addInt('field', 0);
+    }
+
+    public function testToStringReturnsEmptyStringOnInternalError() {
+      $databaseAccess = $this->mockPapaya()->databaseAccess();
+      $statement = new Prepared($databaseAccess, ':trigger');
+      $this->assertEmpty((string)$statement);
+    }
+  }
+}

--- a/tests/system/Papaya/Message/DisplayTest.php
+++ b/tests/system/Papaya/Message/DisplayTest.php
@@ -20,25 +20,23 @@ class DisplayTest extends \Papaya\TestCase {
 
   /**
    * @covers \Papaya\Message\Display::__construct
-   * @covers \Papaya\Message\Display::_isValidType
+   * @covers \Papaya\Message\Display::_isValidSeverity
    */
   public function testConstructor() {
     $message = new Display(\Papaya\Message::SEVERITY_WARNING, 'Sample Message');
-    $this->assertAttributeEquals(
+    $this->assertSame(
       \Papaya\Message::SEVERITY_WARNING,
-      '_type',
-      $message
+      $message->getSeverity()
     );
-    $this->assertAttributeEquals(
+    $this->assertSame(
       'Sample Message',
-      '_message',
-      $message
+      $message->getMessage()
     );
   }
 
   /**
    * @covers \Papaya\Message\Display::__construct
-   * @covers \Papaya\Message\Display::_isValidType
+   * @covers \Papaya\Message\Display::_isValidSeverity
    */
   public function testConstructorWithInvalidTypeExpectingException() {
     $this->expectException(\InvalidArgumentException::class);

--- a/tests/system/Papaya/Message/ManagerTest.php
+++ b/tests/system/Papaya/Message/ManagerTest.php
@@ -59,10 +59,79 @@ class ManagerTest extends \Papaya\TestCase {
     $dispatcher
       ->expects($this->once())
       ->method('dispatch')
-      ->with($this->isInstanceOf(Display::class));
+      ->with($this->isInstanceOf(Display\Translated::class));
     $manager = new Manager();
     $manager->addDispatcher($dispatcher);
     $manager->display(\Papaya\Message::SEVERITY_INFO, 'TEST');
+  }
+
+  /**
+   * @covers \Papaya\Message\Manager::displayInfo
+   */
+  public function testDisplayInfo() {
+    /** @var \PHPUnit_Framework_MockObject_MockObject|Dispatcher $dispatcher */
+    $dispatcher = $this->createMock(Dispatcher::class);
+    $dispatcher
+      ->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->callback(
+          function(Display\Translated $message) {
+            return
+              \Papaya\Message::SEVERITY_INFO === $message->getSeverity() &&
+              'TEST' === $message->getMessage();
+          }
+        )
+      );
+    $manager = new Manager();
+    $manager->addDispatcher($dispatcher);
+    $manager->displayInfo('TEST');
+  }
+
+  /**
+   * @covers \Papaya\Message\Manager::displayWarning
+   */
+  public function testDisplayWarning() {
+    /** @var \PHPUnit_Framework_MockObject_MockObject|Dispatcher $dispatcher */
+    $dispatcher = $this->createMock(Dispatcher::class);
+    $dispatcher
+      ->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->callback(
+          function(Display\Translated $message) {
+            return
+              \Papaya\Message::SEVERITY_WARNING === $message->getSeverity() &&
+              'TEST' === $message->getMessage();
+          }
+        )
+      );
+    $manager = new Manager();
+    $manager->addDispatcher($dispatcher);
+    $manager->displayWarning('TEST');
+  }
+
+  /**
+   * @covers \Papaya\Message\Manager::displayError
+   */
+  public function testDisplayError() {
+    /** @var \PHPUnit_Framework_MockObject_MockObject|Dispatcher $dispatcher */
+    $dispatcher = $this->createMock(Dispatcher::class);
+    $dispatcher
+      ->expects($this->once())
+      ->method('dispatch')
+      ->with(
+        $this->callback(
+          function(Display\Translated $message) {
+            return
+              \Papaya\Message::SEVERITY_ERROR === $message->getSeverity() &&
+              'TEST' === $message->getMessage();
+          }
+        )
+      );
+    $manager = new Manager();
+    $manager->addDispatcher($dispatcher);
+    $manager->displayError('TEST');
   }
 
   /**

--- a/tests/system/Papaya/UI/Content/TeasersTest.php
+++ b/tests/system/Papaya/UI/Content/TeasersTest.php
@@ -92,7 +92,9 @@ namespace Papaya\UI\Content {
             'module_guid' => '12345678901234567890123456789042',
             'content' => 'data',
             'created' => strtotime('2017-01-16T12:21Z'),
-            'modified' => strtotime('2017-01-16T12:21Z')
+            'modified' => strtotime('2017-01-16T12:21Z'),
+            'view_id' => 1,
+            'viewmode_id' => 1
           )
         )
       );
@@ -109,6 +111,7 @@ namespace Papaya\UI\Content {
         ->will($this->returnValue($plugin));
 
       $teasers = new Teasers($pages);
+      $teasers->viewConfigurations($this->createMock(\Papaya\Content\View\Configurations::class));
       $teasers->papaya($this->mockPapaya()->application(array('plugins' => $plugins)));
 
       $this->assertXmlStringEqualsXmlString(
@@ -133,7 +136,9 @@ namespace Papaya\UI\Content {
             'module_guid' => '12345678901234567890123456789021',
             'content' => 'data',
             'created' => strtotime('2017-01-16T12:21Z'),
-            'modified' => strtotime('2017-01-16T12:21Z')
+            'modified' => strtotime('2017-01-16T12:21Z'),
+            'view_id' => 1,
+            'viewmode_id' => 1
           )
         )
       );
@@ -151,6 +156,7 @@ namespace Papaya\UI\Content {
         ->will($this->returnValue($plugin));
 
       $teasers = new Teasers($pages);
+      $teasers->viewConfigurations($this->createMock(\Papaya\Content\View\Configurations::class));
       $teasers->papaya($this->mockPapaya()->application(array('plugins' => $plugins)));
 
       $this->assertXmlStringEqualsXmlString(
@@ -175,7 +181,9 @@ namespace Papaya\UI\Content {
             'module_guid' => '12345678901234567890123456789023',
             'content' => 'data',
             'created' => strtotime('2017-01-16T12:21Z'),
-            'modified' => strtotime('2017-01-16T12:21Z')
+            'modified' => strtotime('2017-01-16T12:21Z'),
+            'view_id' => 1,
+            'viewmode_id' => 1
           )
         )
       );
@@ -188,6 +196,7 @@ namespace Papaya\UI\Content {
         ->will($this->returnValue(NULL));
 
       $teasers = new Teasers($pages);
+      $teasers->viewConfigurations($this->createMock(\Papaya\Content\View\Configurations::class));
       $teasers->papaya($this->mockPapaya()->application(array('plugins' => $plugins)));
 
       $this->assertXmlStringEqualsXmlString(
@@ -212,7 +221,9 @@ namespace Papaya\UI\Content {
             'module_guid' => '12345678901234567890123456789042',
             'content' => 'data',
             'created' => strtotime('2017-01-16T12:21Z'),
-            'modified' => strtotime('2017-01-16T12:21Z')
+            'modified' => strtotime('2017-01-16T12:21Z'),
+            'view_id' => 1,
+            'viewmode_id' => 1
           )
         )
       );
@@ -225,6 +236,7 @@ namespace Papaya\UI\Content {
         ->will($this->returnValue(new Teasers_PagePluginMockClass()));
 
       $teasers = new Teasers($pages, 200, 100);
+      $teasers->viewConfigurations($this->createMock(\Papaya\Content\View\Configurations::class));
       $teasers->papaya($this->mockPapaya()->application(array('plugins' => $plugins)));
 
       $date = \Papaya\Utility\Date::timestampToString(strtotime('2017-01-16T12:21Z'));
@@ -236,8 +248,7 @@ namespace Papaya\UI\Content {
           published='$date'
           page-id='42'
           plugin-guid='12345678901234567890123456789042'
-          plugin='Papaya\UI\Content\Teasers_PagePluginMockClass'
-          href='http://www.test.tld/index.42.html'>
+          plugin='Papaya\UI\Content\Teasers_PagePluginMockClass'>
           <title>sample title</title>
           <image>
             <img src='sample.png'/>


### PR DESCRIPTION
**Formatted**
Uses sprintf and escapes the provided parameters. This class is mostly for BC and easier upgrading.

**Prepared** 
A new approach that uses named parameter syntax ":name" and can handle parameter values according to type. Unlike server side prepared statements it allows for list values and table names.